### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: safe-iop
 Section: libs
 Priority: optional
 Maintainer: Kai-Chung Yan <seamlikok@gmail.com>
-Build-Depends: debhelper (>=9)
+Build-Depends: debhelper
 Standards-Version: 3.9.6
 Homepage: https://code.google.com/p/safe-iop
 Vcs-Git: https://github.com/seamlik/debianpkg-safe-iop.git


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/safe-iop/88dbf5fb-62c8-4014-9abc-44556300e64d.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3b/e559174c43ea00a6b7dc7cdb663fb7e489cd69.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/46/a8f8b7835a528b8f3a2fedc875d89d31f38a82.debug

No differences were encountered between the control files of package \*\*libsafe-iop-dev\*\*

No differences were encountered between the control files of package \*\*libsafe-iop0\*\*
### Control files of package libsafe-iop0-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-46a8f8b7835a528b8f3a2fedc875d89d31f38a82-] {+3be559174c43ea00a6b7dc7cdb663fb7e489cd69+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/88dbf5fb-62c8-4014-9abc-44556300e64d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/88dbf5fb-62c8-4014-9abc-44556300e64d/diffoscope)).
